### PR TITLE
integrate refresh endpoint

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,20 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Store } from '@ngrx/store';
+import * as AuthActions from './common/state/auth/auth.actions';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent {}
+export class AppComponent implements OnInit {
+
+  constructor(private store: Store) {}
+
+  ngOnInit(): void {
+    const accessToken = localStorage.getItem('access_token');
+    if (accessToken) {
+      this.store.dispatch(AuthActions.refreshRequest({access_token: accessToken}));
+    }
+  }
+}

--- a/src/app/common/server-adapters/user-server-adapter.service.ts
+++ b/src/app/common/server-adapters/user-server-adapter.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { Observable, tap } from "rxjs";
-import { LoginDto, JwtReponse, User } from "../types/user";
+import { LoginDto, JwtReponse, User, JwtDto } from "../types/user";
 
 @Injectable({ providedIn: 'root' })
 export class UserServerAdapterService {
@@ -13,5 +13,9 @@ export class UserServerAdapterService {
 
   postSession(loginDto: LoginDto): Observable<JwtReponse> {
     return this.httpClient.post<JwtReponse>('http://localhost:3000/auth/login', loginDto);
+  }
+
+  postRefreshSession(jwtDto: JwtDto): Observable<JwtReponse> {
+    return this.httpClient.post<JwtReponse>('http://localhost:3000/auth/refresh', jwtDto);
   }
 }

--- a/src/app/common/state/auth/auth.actions.ts
+++ b/src/app/common/state/auth/auth.actions.ts
@@ -1,5 +1,5 @@
 import { createAction, props } from "@ngrx/store";
-import { JwtReponse, LoginDto } from "../../types/user";
+import { JwtReponse, LoginDto, JwtDto } from "../../types/user";
 
 export const loginRequest = createAction(
   '[AUTH] Login Request',
@@ -13,5 +13,20 @@ export const loginSuccess = createAction(
 
 export const loginFailure = createAction(
   '[AUTH] Login Failure',
+  props<JwtReponse>()
+);
+
+export const refreshRequest = createAction(
+  '[AUTH] Refresh Request',
+  props<JwtDto>()
+);
+
+export const refreshSuccess = createAction(
+  '[AUTH] Refresh Success',
+  props<JwtReponse>()
+);
+
+export const refreshFailure = createAction(
+  '[AUTH] Refresh Failure',
   props<JwtReponse>()
 );

--- a/src/app/common/state/auth/auth.effects.ts
+++ b/src/app/common/state/auth/auth.effects.ts
@@ -23,10 +23,10 @@ export class AuthEffects {
           .pipe(
             map((response) => AuthActions.loginSuccess(response)),
             catchError((error) => of(AuthActions.loginFailure(error)))
-          )
+          );
       })
     )
-  )
+  );
 
   public loginSuccess$ = createEffect(() =>
     this.actions$.pipe(
@@ -37,7 +37,7 @@ export class AuthEffects {
       })
     ),
     { dispatch: false }
-  )
+  );
 
   public loginFailure$ = createEffect(() =>
     this.actions$.pipe(
@@ -47,5 +47,39 @@ export class AuthEffects {
       })
     ),
     { dispatch: false }
-  )
+  );
+
+  public refreshRequest$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(AuthActions.refreshRequest),
+      exhaustMap((action): ObservableInput<any> => {
+        return this.userServerAdapterService.postRefreshSession(action)
+          .pipe(
+            map((response) => AuthActions.refreshSuccess(response)),
+            catchError((error) => of(AuthActions.refreshFailure(error)))
+          );
+      })
+    )
+  );
+
+  public refreshSuccess$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(AuthActions.refreshSuccess),
+      tap((response) => {
+        localStorage.setItem('access_token', response.access_token as string);
+        this.notificationService.success('Welcome Back!');
+      })
+    ),
+    { dispatch: false }
+  );
+
+  public refreshFailure$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(AuthActions.refreshFailure),
+      tap(() => {
+        this.notificationService.error('Something went wrong. Please log in again.');
+      })
+    ),
+    { dispatch: false }
+  );
 }

--- a/src/app/common/state/auth/auth.reducer.ts
+++ b/src/app/common/state/auth/auth.reducer.ts
@@ -1,6 +1,6 @@
 import { createReducer, on } from "@ngrx/store";
 import { User } from "../../types/user";
-import { loginFailure, loginSuccess } from "./auth.actions";
+import { loginFailure, loginSuccess, refreshFailure, refreshSuccess } from "./auth.actions";
 
 export interface AuthState {
   access_token: string | null;
@@ -28,6 +28,22 @@ export const authReducer = createReducer(
     return {
       ...state,
       loginError: jwtResponse.error,
+      token: null,
+      user: null,
+      isLoggedIn: false
+    }
+  }),
+  on(refreshSuccess, (state, jwtResponse) => {
+    return {
+      ...state,
+      token: jwtResponse.access_token,
+      user: jwtResponse.user,
+      isLoggedIn: true
+    }
+  }),
+  on(refreshFailure, (state, jwtResponse) => {
+    return {
+      ...state,
       token: null,
       user: null,
       isLoggedIn: false

--- a/src/app/common/types/user.ts
+++ b/src/app/common/types/user.ts
@@ -17,3 +17,7 @@ export interface JwtReponse {
   user: User | null;
   error: any | null;
 }
+
+export interface JwtDto {
+  access_token: string;
+}


### PR DESCRIPTION
Added so that when there's an access token in storage on init of the app.component, this will call the refresh endpoint. Probably need to think about adding a isLoading property to state so we don't get a flash of the login component while it loads the logged in user.